### PR TITLE
xds: pass in the ir route name as the xds route name

### DIFF
--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -16,6 +16,7 @@ import (
 
 func buildXdsRoute(httpRoute *ir.HTTPRoute) *route.Route {
 	ret := &route.Route{
+		Name:  httpRoute.Name,
 		Match: buildXdsRouteMatch(httpRoute.PathMatch, httpRoute.HeaderMatches, httpRoute.QueryParamMatches),
 	}
 

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.routes.yaml
@@ -10,3 +10,4 @@
         status: 500
       match:
         prefix: /
+      name: direct-route

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.routes.yaml
@@ -6,6 +6,7 @@
     routes:
     - match:
         prefix: /
+      name: redirect-route
       redirect:
         hostRedirect: redirected.com
         portRedirect: 8443

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
@@ -6,6 +6,7 @@
     routes:
     - match:
         prefix: /
+      name: request-header-route
       requestHeadersToAdd:
       - append: true
         header:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.routes.yaml
@@ -6,6 +6,7 @@
     routes:
     - match:
         prefix: /
+      name: response-header-route
       responseHeadersToAdd:
       - append: true
         header:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.routes.yaml
@@ -6,6 +6,7 @@
     routes:
     - match:
         prefix: /
+      name: response-header-route
       responseHeadersToAdd:
       - append: true
         header:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.routes.yaml
@@ -6,6 +6,7 @@
     routes:
     - match:
         prefix: /
+      name: response-header-route
       responseHeadersToRemove:
       - some-header5
       - some-header6

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.routes.yaml
@@ -10,6 +10,7 @@
           stringMatch:
             exact: gateway.envoyproxy.io
         prefix: /origin
+      name: rewrite-route
       route:
         cluster: rewrite-route
         regexRewrite:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.routes.yaml
@@ -10,6 +10,7 @@
           stringMatch:
             exact: gateway.envoyproxy.io
         prefix: /origin
+      name: rewrite-route
       route:
         appendXForwardedHost: true
         cluster: rewrite-route

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.routes.yaml
@@ -10,6 +10,7 @@
           stringMatch:
             exact: gateway.envoyproxy.io
         prefix: /origin
+      name: rewrite-route
       route:
         cluster: rewrite-route
         prefixRewrite: /rewrite

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.routes.yaml
@@ -6,5 +6,6 @@
     routes:
     - match:
         prefix: /
+      name: first-route
       route:
         cluster: first-route

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.routes.yaml
@@ -6,6 +6,7 @@
     routes:
     - match:
         prefix: /
+      name: first-route
       route:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
         weightedClusters:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
@@ -17,5 +17,6 @@
         - name: debug
           stringMatch:
             exact: "yes"
+      name: first-route
       route:
         cluster: first-route

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.routes.yaml
@@ -14,5 +14,6 @@
         - name: debug
           stringMatch:
             exact: "yes"
+      name: first-route
       route:
         cluster: first-route

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.routes.yaml
@@ -6,6 +6,7 @@
     routes:
     - match:
         prefix: /
+      name: first-route
       route:
         cluster: first-route
 - name: second-listener
@@ -16,6 +17,7 @@
     routes:
     - match:
         prefix: /
+      name: second-route
       route:
         cluster: second-route
 - name: third-listener
@@ -26,6 +28,7 @@
     routes:
     - match:
         prefix: /
+      name: third-route
       route:
         cluster: third-route
   - domains:
@@ -34,5 +37,6 @@
     routes:
     - match:
         prefix: /
+      name: fourth-route
       route:
         cluster: fourth-route

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.routes.yaml
@@ -6,6 +6,7 @@
     routes:
     - match:
         path: foo/bar
+      name: first-route
       route:
         cluster: first-route
         rateLimits:
@@ -20,6 +21,7 @@
                   exact: one
     - match:
         path: example
+      name: second-route
       route:
         cluster: second-route
         rateLimits:
@@ -29,6 +31,7 @@
               headerName: x-user-id
     - match:
         path: test
+      name: third-route
       route:
         cluster: third-route
         rateLimits:

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.routes.yaml
@@ -6,5 +6,6 @@
     routes:
     - match:
         prefix: /
+      name: first-route
       route:
         cluster: first-route


### PR DESCRIPTION
Pass in the route name from the IR to xDS.

It's of the format `%(namespace)s-%(HTTPRouteName)-rule-%(HTTPRouteRuleIdx)d-match-%(HTTPRouteMatchIdx)d` which should be enough to guarantee uniqueness in route names