### PR TITLE
extension: update k8s provider & IR translator for recognize extensions

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -10,6 +10,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	extensionregistry "github.com/envoyproxy/gateway/internal/extension/registry"
 	gatewayapirunner "github.com/envoyproxy/gateway/internal/gatewayapi/runner"
 	infrarunner "github.com/envoyproxy/gateway/internal/infrastructure/runner"
 	"github.com/envoyproxy/gateway/internal/message"
@@ -91,6 +92,12 @@ func setupRunners(cfg *config.Server) error {
 	// https://github.com/envoyproxy/gateway/issues/43
 	ctx := ctrl.SetupSignalHandler()
 
+	// Setup the Extension Manager
+	extMgr, err := extensionregistry.NewManager(cfg)
+	if err != nil {
+		return err
+	}
+
 	pResources := new(message.ProviderResources)
 	// Start the Provider Service
 	// It fetches the resources from the configured provider type
@@ -98,6 +105,7 @@ func setupRunners(cfg *config.Server) error {
 	providerRunner := providerrunner.New(&providerrunner.Config{
 		Server:            *cfg,
 		ProviderResources: pResources,
+		ExtensionManager:  extMgr,
 	})
 	if err := providerRunner.Start(ctx); err != nil {
 		return err
@@ -113,6 +121,7 @@ func setupRunners(cfg *config.Server) error {
 		ProviderResources: pResources,
 		XdsIR:             xdsIR,
 		InfraIR:           infraIR,
+		ExtensionManager:  extMgr,
 	})
 	if err := gwRunner.Start(ctx); err != nil {
 		return err
@@ -161,6 +170,11 @@ func setupRunners(cfg *config.Server) error {
 	xds.Close()
 
 	cfg.Logger.Info("shutting down")
+
+	// Close connections to extension services
+	if mgr, ok := extMgr.(*extensionregistry.Manager); ok {
+		mgr.CleanupHookConns()
+	}
 
 	return nil
 }

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	extTypes "github.com/envoyproxy/gateway/internal/extension/types"
 )
 
 const (
@@ -180,7 +181,7 @@ func HasReadyListener(listeners []*ListenerContext) bool {
 }
 
 // ValidateHTTPRouteFilter validates the provided filter within HTTPRoute.
-func ValidateHTTPRouteFilter(filter *v1beta1.HTTPRouteFilter) error {
+func ValidateHTTPRouteFilter(em extTypes.Manager, filter *v1beta1.HTTPRouteFilter) error {
 	switch {
 	case filter == nil:
 		return errors.New("filter is nil")
@@ -191,14 +192,20 @@ func ValidateHTTPRouteFilter(filter *v1beta1.HTTPRouteFilter) error {
 		filter.Type == v1beta1.HTTPRouteFilterResponseHeaderModifier:
 		return nil
 	case filter.Type == v1beta1.HTTPRouteFilterExtensionRef:
-		switch {
-		case filter.ExtensionRef == nil:
+		if filter.ExtensionRef == nil {
 			return errors.New("extensionRef field must be specified for an extended filter")
-		case string(filter.ExtensionRef.Group) != egv1a1.GroupVersion.Group:
-			return fmt.Errorf("invalid group; must be %s", egv1a1.GroupVersion.Group)
-		case string(filter.ExtensionRef.Kind) != egv1a1.AuthenticationFilterKind:
-			return fmt.Errorf("invalid kind; must be %s", egv1a1.AuthenticationFilterKind)
+		}
+
+		switch string(filter.ExtensionRef.Group) {
+		case egv1a1.GroupVersion.Group:
+			if string(filter.ExtensionRef.Kind) != egv1a1.AuthenticationFilterKind {
+				return fmt.Errorf("invalid kind for group %s; must be %s", egv1a1.GroupVersion.Group, egv1a1.AuthenticationFilterKind)
+			}
+			return nil
 		default:
+			if ok, _ := em.HasExtension(filter.ExtensionRef.Group, filter.ExtensionRef.Kind); !ok {
+				return fmt.Errorf("unrecognized group and/or kind: Group: %s; Kind: %s", filter.ExtensionRef.Group, filter.ExtensionRef.Kind)
+			}
 			return nil
 		}
 	}

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -205,6 +205,9 @@ func (t *Translator) processHTTPRouteRule(httpRoute *HTTPRouteContext, ruleIdx i
 		if httpFiltersContext.URLRewrite != nil {
 			irRoute.URLRewrite = httpFiltersContext.URLRewrite
 		}
+		if httpFiltersContext.Extensions != nil {
+			irRoute.Extensions = httpFiltersContext.Extensions
+		}
 		if len(httpFiltersContext.AddRequestHeaders) > 0 {
 			irRoute.AddRequestHeaders = httpFiltersContext.AddRequestHeaders
 		}
@@ -269,6 +272,7 @@ func (t *Translator) processHTTPRouteParentRefListener(httpRoute *HTTPRouteConte
 					Redirect:              routeRoute.Redirect,
 					DirectResponse:        routeRoute.DirectResponse,
 					URLRewrite:            routeRoute.URLRewrite,
+					Extensions:            routeRoute.Extensions,
 				}
 				// Don't bother copying over the weights unless the route has invalid backends.
 				if routeRoute.BackendWeights.Invalid > 0 {

--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	extension "github.com/envoyproxy/gateway/internal/extension/types"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/message"
 	"github.com/envoyproxy/gateway/internal/provider/utils"
@@ -22,6 +23,7 @@ type Config struct {
 	ProviderResources *message.ProviderResources
 	XdsIR             *message.XdsIR
 	InfraIR           *message.InfraIR
+	ExtensionManager  extension.Manager
 }
 
 type Runner struct {
@@ -56,6 +58,7 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 			// Translate and publish IRs.
 			t := &gatewayapi.Translator{
 				GatewayClassName: v1beta1.ObjectName(update.Key),
+				ExtensionManager: r.ExtensionManager,
 			}
 			// Translate to IR
 			result := t.Translate(val)

--- a/internal/gatewayapi/runner/runner_test.go
+++ b/internal/gatewayapi/runner/runner_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	"github.com/envoyproxy/gateway/internal/extension/testutils"
 	"github.com/envoyproxy/gateway/internal/ir"
 	"github.com/envoyproxy/gateway/internal/message"
 )
@@ -31,6 +32,7 @@ func TestRunner(t *testing.T) {
 		ProviderResources: pResources,
 		XdsIR:             xdsIR,
 		InfraIR:           infraIR,
+		ExtensionManager:  testutils.NewManager(),
 	})
 	ctx := context.Background()
 	// Start

--- a/internal/gatewayapi/testdata/httproute-using-extension.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-using-extension.in.yaml
@@ -1,0 +1,42 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          group: foo.example.io
+          kind: Bar
+          name: baz

--- a/internal/gatewayapi/testdata/httproute-using-extension.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-using-extension.out.yaml
@@ -49,9 +49,10 @@ httpRoutes:
       filters:
       - type: ExtensionRef
         extensionRef:
-          group: unsupported.group.io
-          kind: UnsupportedKind
-          name: unsupported
+          group: foo.example.io
+          kind: Bar
+          name: baz
+
   status:
     parents:
     - parentRef:
@@ -61,9 +62,9 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "False"
-        reason: UnsupportedValue
-        message: "Invalid filter ExtensionRef: unrecognized group and/or kind: Group: unsupported.group.io; Kind: UnsupportedKind"
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:
@@ -79,11 +80,17 @@ xdsIR:
         headerMatches:
         - name: ":authority"
           exact: gateway.envoyproxy.io
-        # I believe the correct way to handle an invalid filter should be to allow the HTTPRoute to function
-        # normally but leave out the filter config and set the status, but this behaviour can be changed.
-        directResponse:
-          body: "Invalid filter ExtensionRef: unrecognized group and/or kind: Group: unsupported.group.io; Kind: UnsupportedKind"
-          statusCode: 500
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+        extensions:
+          extensionId: foo
+          httpRouteNamespace: default
+          extensionRefs:
+          - group: foo.example.io
+            kind: Bar
+            name: baz
 infraIR:
   envoy-gateway-gateway-1:
     proxy:

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -8,6 +8,8 @@ package gatewayapi
 import (
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	extension "github.com/envoyproxy/gateway/internal/extension/types"
 )
 
 const (
@@ -57,6 +59,10 @@ type Translator struct {
 	// the Infra IR. If unspecified, the default proxy
 	// image will be used.
 	ProxyImage string
+
+	// ExtensionManager manages extensions to support
+	// additional filters for HTTRouteFilter extensionRef
+	ExtensionManager extension.Manager
 }
 
 type TranslateResult struct {

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -20,7 +20,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwapiv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/yaml"
+
+	"github.com/envoyproxy/gateway/api/config/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/extension/testutils"
 )
 
 func mustUnmarshal(t *testing.T, val string, out interface{}) {
@@ -46,9 +50,17 @@ func TestTranslate(t *testing.T) {
 			want := &TranslateResult{}
 			mustUnmarshal(t, string(output), want)
 
+			ext := v1alpha1.Extension{
+				Name: "foo",
+				APIGroups: []gwapiv1beta1.Group{
+					"foo.example.io",
+				},
+			}
+
 			translator := &Translator{
 				GatewayClassName: "envoy-gateway-class",
 				ProxyImage:       "envoyproxy/envoy:translator-tests",
+				ExtensionManager: testutils.NewManager(ext),
 			}
 
 			// Add common test fixtures

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"net"
 
+	"github.com/envoyproxy/gateway/api/config/v1alpha1"
 	"github.com/tetratelabs/multierror"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 var (
@@ -215,6 +217,8 @@ type HTTPRoute struct {
 	// RateLimit defines the more specific match conditions as well as limits for ratelimiting
 	// the requests on this route.
 	RateLimit *RateLimit
+	// ExtensionRefs defines filters containin extensionRefs to resources managed by an Envoy Gateway extension.
+	Extensions *HTTPFilterExtensionRefs
 }
 
 // Validate the fields within the HTTPRoute structure
@@ -644,4 +648,16 @@ type RateLimitValue struct {
 	Requests uint32
 	// Unit of rate limiting.
 	Unit RateLimitUnit
+}
+
+type HTTPFilterExtensionRefs struct {
+	// ExtensionId is the ID of the registered extension that will handle the extensionRefs
+	ExtensionId   v1alpha1.ExtensionId
+	// Namespace of the HTTPRoute Gateway API resource
+	//
+	// TODO: It may make more sense to add this field to HTTPRoute instead but don't want to update
+	// a bunch of testdata files so adding it here for now.
+	HTTPRouteNamespace string
+	// ExtensionRefs are the filters of type extensionRef referencing an APIGroup/Kind registered by ExtensionID
+	ExtensionRefs []*v1beta1.LocalObjectReference
 }

--- a/internal/provider/kubernetes/kubernetes.go
+++ b/internal/provider/kubernetes/kubernetes.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/envoyproxy/gateway/internal/envoygateway"
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	extension "github.com/envoyproxy/gateway/internal/extension/types"
 	"github.com/envoyproxy/gateway/internal/message"
 	"github.com/envoyproxy/gateway/internal/status"
 )
@@ -30,7 +31,7 @@ type Provider struct {
 }
 
 // New creates a new Provider from the provided EnvoyGateway.
-func New(cfg *rest.Config, svr *config.Server, resources *message.ProviderResources) (*Provider, error) {
+func New(cfg *rest.Config, svr *config.Server, resources *message.ProviderResources, extManger extension.Manager) (*Provider, error) {
 	// TODO: Decide which mgr opts should be exposed through envoygateway.provider.kubernetes API.
 	mgrOpts := manager.Options{
 		Scheme:                 envoygateway.GetScheme(),
@@ -51,7 +52,7 @@ func New(cfg *rest.Config, svr *config.Server, resources *message.ProviderResour
 	}
 
 	// Create and register the controllers with the manager.
-	if err := newGatewayAPIController(mgr, svr, updateHandler.Writer(), resources); err != nil {
+	if err := newGatewayAPIController(mgr, svr, updateHandler.Writer(), resources, extManger); err != nil {
 		return nil, fmt.Errorf("failted to create gatewayapi controller: %w", err)
 	}
 

--- a/internal/provider/kubernetes/routes.go
+++ b/internal/provider/kubernetes/routes.go
@@ -205,12 +205,13 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 
 			for i := range rule.Filters {
 				filter := rule.Filters[i]
-				if err := gatewayapi.ValidateHTTPRouteFilter(&filter); err != nil {
+				if err := gatewayapi.ValidateHTTPRouteFilter(r.extensionManager, &filter); err != nil {
 					r.log.Error(err, "bypassing filter rule", "index", i)
 					continue
 				}
 
-				if filter.Type == gwapiv1b1.HTTPRouteFilterExtensionRef {
+				if filter.Type == gwapiv1b1.HTTPRouteFilterExtensionRef &&
+					filter.ExtensionRef.Group == gwapiv1b1.Group(egv1a1.GroupVersion.Group) {
 					authenFilter, err := r.getAuthenticationFilter(ctx, httpRoute.Namespace, string(filter.ExtensionRef.Name))
 					if err != nil {
 						r.log.Error(err, "bypassing filter rule", "index", i)

--- a/internal/provider/runner/runner.go
+++ b/internal/provider/runner/runner.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/envoyproxy/gateway/api/config/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	extension "github.com/envoyproxy/gateway/internal/extension/types"
 	"github.com/envoyproxy/gateway/internal/message"
 	"github.com/envoyproxy/gateway/internal/provider/kubernetes"
 )
@@ -20,6 +21,7 @@ import (
 type Config struct {
 	config.Server
 	ProviderResources *message.ProviderResources
+	ExtensionManager  extension.Manager
 }
 
 type Runner struct {
@@ -43,7 +45,7 @@ func (r *Runner) Start(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to get kubeconfig: %w", err)
 		}
-		p, err := kubernetes.New(cfg, &r.Config.Server, r.ProviderResources)
+		p, err := kubernetes.New(cfg, &r.Config.Server, r.ProviderResources, r.ExtensionManager)
 		if err != nil {
 			return fmt.Errorf("failed to create provider %s: %w", v1alpha1.ProviderTypeKubernetes, err)
 		}


### PR DESCRIPTION
**Note**: relies on https://github.com/datawire/envoy-gateway/pull/9

1. Update IR to track extensionRefs to APIGroup/Kinds managed by extensions
2. Update the validation functions to not error out if an extensionRef API group is not the Envoy Gateway API Group, it now checks with the Extension Manager first to see if the API Group is handled by a registered extension first.
3. Update the IR translator to note extensionRefs using API Group/Kinds managed by extensions
4. Update the Kubernetes provider for updates to validation functions  